### PR TITLE
Import sys to allow error output

### DIFF
--- a/core/alpino_dependency.py
+++ b/core/alpino_dependency.py
@@ -1,4 +1,6 @@
 import re
+import sys
+
 from KafNafParserPy import Cdependency
 
 '''


### PR DESCRIPTION
sys was not imported, causing an exception on trying to print the exception content.

(btw, it might be worth using the logging module and using logging.exception instead, that also gives you a traceback)
