### PR TITLE
Check that alpino generated at least one dependency

### DIFF
--- a/core/morph_syn_parser.py
+++ b/core/morph_syn_parser.py
@@ -148,14 +148,19 @@ def process_alpino_xml(xml_file,sentence,count_terms,knaf_obj,cnt_t,cnt_nt,cnt_e
     alpino_bin = os.path.join(os.environ['ALPINO_HOME'],'bin','Alpino')
     cmd = [alpino_bin, '-treebank_triples', xml_file]
     output = check_output(cmd)
-    
+    has_dependencies = False
     for line in output.splitlines():
         line = line.strip().decode('utf-8')
         my_dep = Calpino_dependency(line)
         if my_dep.is_ok():
             deps = my_dep.generate_dependencies(term_ids)
             for d in deps:
-               knaf_obj.add_dependency(d)
+                has_dependencies = True
+                knaf_obj.add_dependency(d)
+    if not has_dependencies:
+        # Something is wrong, presumably a problem within Alpino
+        raise Exception("Could not extract dependencies from the parse xml")
+    
     ##########################################
 
     # we return the counters for terms and consituent elements to keep generating following identifiers for next sentnces


### PR DESCRIPTION
Simple check to make sure Alpino generates at least one dependency. 

It might be better to do a post-hoc check that the generated xml has certain properties (e.g. contains a dependency layer), but for now this will at least signal the version problem.

Unfortunately, Alpino doesn't throw an error, so if you have a document that legitimately contains no dependencies (perhaps it's a single word), this will raise a false negative, so I guess it's up to you whether you think this is a good addition?
