### PR TITLE
use Alpino server and python3 compat

### DIFF
--- a/core/alpino_dependency.py
+++ b/core/alpino_dependency.py
@@ -1,5 +1,7 @@
+import logging
 import re
 import sys
+from xml.sax.saxutils import escape
 
 from KafNafParserPy import Cdependency
 
@@ -53,7 +55,7 @@ class Calpino_dependency:
                 for t_to in terms_to:
                     ##Creating comment
                     str_comment = ' '+self.relation+'('+self.lemma_to+','+self.lemma_from+') '
-                    str_comment = str_comment.encode('ascii', 'xmlcharrefreplace')
+                    str_comment = escape(str_comment)
                     
                     my_dep = Cdependency()
                     my_dep.set_from(t_to)
@@ -63,5 +65,5 @@ class Calpino_dependency:
                     
                     dependencies.append(my_dep)
         except Exception as e:
-            print>>sys.stderr,str(e)
+            logging.exception("Error on generating dependencies")
         return dependencies

--- a/core/convert_penn_to_kaf.py
+++ b/core/convert_penn_to_kaf.py
@@ -2,7 +2,7 @@ from lxml import etree
 from KafNafParserPy import *
 from tree import Tree
 import logging
-
+from xml.sax.saxutils import escape
 
 
 ## will be used as global variables to generate recursively the KAF constituent nodes
@@ -104,8 +104,7 @@ def convert_penn_to_knaf_with_numtokens(tree_str,term_ids,lemma_for_termid,off_t
             label_from = lemma_for_ter.get(node_from,'kk')
                                         
         comment = '  '+(edge_id)+'  '+(label_to)+' <- '+(label_from)+' '
-        comment = comment.replace('--','-')
-        comment = comment.encode('ascii', 'xmlcharrefreplace')
+        comment = escape(comment.replace('--','-'))
         if node_from in nonter_heads:
             edge_obj.set_as_head()
         edge_obj.set_comment(comment)

--- a/core/morph_syn_parser.py
+++ b/core/morph_syn_parser.py
@@ -80,7 +80,7 @@ def node_to_penn(node,map_token_begin_node):
                 head = '=H'
             else:
                 head = ''
-            return '('+node.get('pos')+head+' '+word.encode('utf-8')+')'
+            return '('+node.get('pos')+head+' '+word+')'
         else:
             return ''
     else:
@@ -109,7 +109,7 @@ def process_alpino_xml(xml_tree, dependencies, sentence,count_terms,knaf_obj,cnt
 
     term_ids = []
     lemma_for_termid = {}
-    print>>sys.stderr,'  Creating the term layer...'
+    logging.info('Creating the term layer...')
     for num_token, (token,token_id) in enumerate(sentence):
         new_term_id = 't_'+str(count_terms)
         count_terms+=1
@@ -134,7 +134,7 @@ def process_alpino_xml(xml_tree, dependencies, sentence,count_terms,knaf_obj,cnt
 
     ##########################################
     ##Constituency layer
-    print>>sys.stderr,'  Creating the constituency layer...'
+    logging.info('Creating the constituency layer...')
     tree_obj,cnt_t,cnt_nt,cnt_edge = convert_penn_to_knaf_with_numtokens(penn_tree_str,term_ids,lemma_for_termid,cnt_t,cnt_nt,cnt_edge)
     knaf_obj.add_constituency_tree(tree_obj)
     ##########################################
@@ -237,7 +237,7 @@ def run_morph_syn_parser(input_file, output_file, max_min_per_sent=None):
 
     lang = in_obj.get_language()
     if lang != 'nl':
-        print>>sys.stdout,'ERROR! Language is ',lang,' and must be nl (Dutch)'
+        logging.warning('ERROR! Language is {} and must be nl (Dutch)'.format(lang))
         sys.exit(-1)
 
     ## Sentences is a list of lists containing pairs token, tokenid
@@ -275,7 +275,7 @@ def run_morph_syn_parser(input_file, output_file, max_min_per_sent=None):
     in_obj.add_linguistic_processor('deps',my_lp_deps)
     ####################
 
-    in_obj.dump(sys.stdout)
+    in_obj.dump()
 
 
 

--- a/core/tree.py
+++ b/core/tree.py
@@ -18,6 +18,7 @@ syntax trees and morphological trees.
 
 import re
 import string
+from six import string_types as basestring
 
 ######################################################################
 ## Trees
@@ -313,7 +314,7 @@ class Tree(list):
         """
 
         if not isinstance(self.node, basestring):
-            raise TypeError, 'Productions can only be generated from trees having node labels that are strings'
+            raise TypeError('Productions can only be generated from trees having node labels that are strings')
 
         prods = [Production(Nonterminal(self.node), _child_names(self))]
         for child in self:
@@ -1369,63 +1370,63 @@ def demo():
     # Demonstrate tree parsing.
     s = '(S (NP (DT the) (NN cat)) (VP (VBD ate) (NP (DT a) (NN cookie))))'
     t = Tree(s)
-    print "Convert bracketed string into tree:"
-    print t
-    print t.__repr__()
+    print("Convert bracketed string into tree:")
+    print(t)
+    print(t.__repr__())
 
-    print "Display tree properties:"
-    print t.node           # tree's constituent type
-    print t[0]             # tree's first child
-    print t[1]             # tree's second child
-    print t.height()
-    print t.leaves()
-    print t[1]
-    print t[1,1]
-    print t[1,1,0]
+    print("Display tree properties:")
+    print(t.node)           # tree's constituent type
+    print(t[0])             # tree's first child
+    print(t[1])             # tree's second child
+    print(t.height())
+    print(t.leaves())
+    print(t[1])
+    print(t[1,1])
+    print(t[1,1,0])
 
     # Demonstrate tree modification.
     the_cat = t[0]
     the_cat.insert(1, tree.Tree.parse('(JJ big)'))
-    print "Tree modification:"
-    print t
+    print("Tree modification:")
+    print(t)
     t[1,1,1] = tree.Tree.parse('(NN cake)')
-    print t
-    print
+    print()
+    print()
 
     # Tree transforms
-    print "Collapse unary:"
+    print( "Collapse unary:")
     t.collapse_unary()
-    print t
-    print "Chomsky normal form:"
+    print(t)
+    print("Chomsky normal form:")
     t.chomsky_normal_form()
-    print t
-    print
+    print( t)
+    print()
 
     # Demonstrate probabilistic trees.
     pt = tree.ProbabilisticTree('x', ['y', 'z'], prob=0.5)
-    print "Probabilistic Tree:"
-    print pt
-    print
+    print("Probabilistic Tree:")
+    print(pt)
+    print()
 
     # Demonstrate parsing of treebank output format.
     t = tree.Tree.parse(t.pprint())
-    print "Convert tree to bracketed string and back again:"
-    print t
-    print
+    print("Convert tree to bracketed string and back again:")
+    print(t)
+    print()
 
     # Demonstrate LaTeX output
-    print "LaTeX output:"
-    print t.pprint_latex_qtree()
-    print
+    print("LaTeX output:")
+    print(t.pprint_latex_qtree())
+    print()
 
     # Demonstrate Productions
-    print "Production output:"
-    print t.productions()
-    print
+    print("Production output:")
+    print(t.productions())
+    print()
 
     # Demonstrate tree nodes containing objects other than strings
     t.node = ('test', 3)
-    print t
+    print(t)
 
 __all__ = ['ImmutableProbabilisticTree', 'ImmutableTree', 'ProbabilisticMixIn',
            'ProbabilisticTree', 'Tree', 'bracket_parse',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-nose
 KafNafParserPy
-
+requests
+six


### PR DESCRIPTION
Hey @rubenIzquierdo (cc @antske )

I have created a Dockerfile for alpino that let's you run it as a server, which can output XML+dependencies automatically (see github.com/vanatteveldt/alpino-server). 

This PR checks for an ALPINO_SERVER env var if ALPINO_HOME is not found, and then parses via a GET request to the server. 

I've refactored the code a bit so all the Alpino calls are in a separate function (call_alpino; https://github.com/vanatteveldt/morphosyntactic_parser_nl/commit/d2bda281be14e5e7c80dd07bd5cadbede351efbb). The next commit branches call_alpino  into a local and server version (https://github.com/vanatteveldt/morphosyntactic_parser_nl/commit/8c1466e53fe32798aee5b7e98a730f3551c27b84)

I've also modified a couple of small things to make it python3 compatible (https://github.com/vanatteveldt/morphosyntactic_parser_nl/commit/067efdacb1d66f7e849f0426eef85337c7e348e9). I only checked with a simple example so it's quite possible that something is still not compatible. 

(I will now actively test this so I might stlil run into issues)

Let me know what you think!

-- Wouter 

Edit: the automatic test  is broken because it downloads a nonexisting alpino, I might fix that if I have time :)